### PR TITLE
Made cpp parameter datatypes match the header datatypes

### DIFF
--- a/src/ModbusRTUMaster.cpp
+++ b/src/ModbusRTUMaster.cpp
@@ -40,7 +40,7 @@ void ModbusRTUMaster::setTimeout(uint32_t timeout) {
   _responseTimeout = timeout;
 }
 
-void ModbusRTUMaster::begin(unsigned long baud, uint8_t config) {
+void ModbusRTUMaster::begin(uint32_t baud, uint8_t config) {
   if (_hardwareSerial) {
     _calculateTimeouts(baud, config);
     _hardwareSerial->begin(baud, config);
@@ -286,7 +286,7 @@ void ModbusRTUMaster::_clearRxBuffer() {
 
 
 
-void ModbusRTUMaster::_calculateTimeouts(unsigned long baud, uint8_t config) {
+void ModbusRTUMaster::_calculateTimeouts(uint32_t baud, uint8_t config) {
   uint32_t bitsPerChar;
   if (config == SERIAL_8E2 || config == SERIAL_8O2) bitsPerChar = 12;
   else if (config == SERIAL_8N2 || config == SERIAL_8E1 || config == SERIAL_8O1) bitsPerChar = 11;


### PR DESCRIPTION
I got a compile error when trying to compile for ESP32. Headerfile uses uint32_t, while cpp file uses unsigned long.

Compiler typically says:
error: no declaration matches 'void ModbusRTUMaster::_calculateTimeouts(long unsigned int, uint8_t)'
note: candidate is: 'void ModbusRTUMaster::_calculateTimeouts(uint32_t, uint8_t)'