### PR TITLE
millis() and micros() return unsigned long

### DIFF
--- a/src/ModbusRTUMaster.cpp
+++ b/src/ModbusRTUMaster.cpp
@@ -271,7 +271,7 @@ void ModbusRTUMaster::_writeRequest(uint8_t len) {
 }
 
 uint16_t ModbusRTUMaster::_readResponse(uint8_t id, uint8_t functionCode) {
-  uint32_t startTime = millis();
+  unsigned long startTime = millis();
   uint16_t numBytes = 0;
   while (!_serial->available()) {
     if (millis() - startTime >= _responseTimeout) {


### PR DESCRIPTION
I did not experience a bug situation (so no need for immediate release) but compiler complained and according to https://www.arduino.cc/reference/en/language/functions/time/millis/ , "The return value for millis() is of type unsigned long, logic errors may occur if a programmer tries to do arithmetic with smaller data types such as int.". Especially for "startTime = micros();" there could be some data truncating leading to unexpected behaviour.